### PR TITLE
refactor(osu.js): use markdown timestamps

### DIFF
--- a/osu.js
+++ b/osu.js
@@ -1062,7 +1062,7 @@ module.exports = {
 
         lines[0] += `${recent.score.toLocaleString()}${helper.sep}`;
         lines[0] += `${+recent.acc.toFixed(2)}%${helper.sep}`;
-        lines[0] += `${DateTime.fromSQL(recent.date).toRelative()}`;
+        lines[0] += `<t:${DateTime.fromSQL(recent.date).toSeconds()}:R>`;
 
         if(recent.pp_fc > recent.pp)
             lines[1] += `**${recent.unsubmitted ? '*' : ''}${+recent.pp.toFixed(2)}pp**${recent.unsubmitted ? '*' : ''} ➔ ${+recent.pp_fc.toFixed(2)}pp for ${+recent.acc_fc.toFixed(2)}% FC${helper.sep}`;


### PR DESCRIPTION
This PR switches the time display in top play embeds to markdown timestamps, which dynamically update.
![image](https://user-images.githubusercontent.com/43897385/124377488-017f7200-dc61-11eb-9401-1bcde86dfe1b.png)
![image](https://user-images.githubusercontent.com/43897385/124377500-122fe800-dc61-11eb-890b-7817726d4d4a.png)
