### PR TITLE
fix crash when ffmpeg fails during hitsound rendering

### DIFF
--- a/renderer/render_frame.js
+++ b/renderer/render_frame.js
@@ -137,7 +137,7 @@ async function renderHitsounds(mediaPromise, beatmap, start_time, actual_length,
 		for(const scoringFrame of scoringFrames){
 			if(scoringFrame.combo >= scoringFrame.previousCombo || scoringFrame.previousCombo < 30)
 				continue;
-	
+
 			hitSounds.push({
 				offset: (scoringFrame.offset - start_time) / time_scale,
 				sound: 'combobreak',
@@ -156,7 +156,7 @@ async function renderHitsounds(mediaPromise, beatmap, start_time, actual_length,
 			if(beatmap.Replay.auto !== true){
 				if(hitObject.hitOffset == null)
 					continue;
-	
+
 				offset += hitObject.hitOffset;
 			}
 
@@ -175,7 +175,7 @@ async function renderHitsounds(mediaPromise, beatmap, start_time, actual_length,
 				}
 			}
 		}
-		
+
 		if(hitObject.objectName == 'slider'){
 			hitObject.EdgeHitSounds.forEach((edgeHitSounds, index) => {
 				edgeHitSounds.forEach(hitSound => {
@@ -184,7 +184,7 @@ async function renderHitsounds(mediaPromise, beatmap, start_time, actual_length,
 					if(index == 0 && beatmap.Replay.auto !== true){
 						if(hitObject.hitOffset == null)
 							return;
-						
+
 						offset += hitObject.hitOffset;
 					}
 
@@ -306,7 +306,7 @@ async function renderHitsounds(mediaPromise, beatmap, start_time, actual_length,
 			await execFilePromise(ffmpeg, mergeArgs, { shell: true });
 
 			resolve(path.resolve(file_path, 'merged.wav'));
-		});
+		}).catch(reject);
 	});
 }
 
@@ -377,7 +377,7 @@ async function downloadMedia(options, beatmap, beatmap_path, size, download_path
 				{ apply: 'shade', params: [80] }
 			])
 			.writeAsync(path.resolve(extraction_path, 'bg.png'));
-	
+
 			output.background_path = path.resolve(extraction_path, 'bg.png');
 		}catch(e){
 			output.background_path = null;
@@ -787,7 +787,7 @@ module.exports = {
 								name: `video.${options.type}`
 							}]}).then(() => {
 								fs.promises.rm(file_path, { recursive: true }).catch(helper.error);
-							}).catch(console.error);					 
+							}).catch(console.error);
 						});
 
 						ffmpegProcess.stderr.on('data', data => {


### PR DESCRIPTION
This just adds a catch to a `Promise.all` in `renderHitsounds()` in render_frame.js. Without it, the render would get stuck forever after ffmpeg exits unexpectedly instead of either failing completely or recovering. The specific issue we ran into was with a hitsound audio file that ffmpeg couldn't handle (ogg vorbis inside a .wav container). Command to reproduce the issue: `!render https://osu.ppy.sh/beatmapsets/1276314#osu/2651771 strains 60s`.

Still testing various maps, will edit to a full PR once I feel confident this doesn't introduce any regressions.


The output from when ffmpeg exited with exit code 1:
```
Error: Command failed: /path/to/node_modules/ffmpeg-static/ffmpeg <..truncated..>
<..truncated..>
Input #6, wav, from '/tmp/frames/519695412/map/drum-hitclap.wav':
  Metadata:
    encoder         : Slicex
  Duration: 00:00:04.00, bitrate: 92 kb/s
  Stream #6:0: Audio: none (Og[0][0] / 0x674F), 44100 Hz, 2 channels, 128 kb/s
<..truncated..>
Stream mapping:
  Stream #0:0 (pcm_s16le) -> adelay
  Stream #0:0 (pcm_s16le) -> adelay
  Stream #0:0 (pcm_s16le) -> adelay
  <..truncated..>
  Stream #4:0 (pcm_s16le) -> adelay
  Stream #5:0 (pcm_s16le) -> adelay
  Stream #5:0 (pcm_s16le) -> adelay
  Stream #5:0 (pcm_s16le) -> adelay
  Stream #6:0 (?) -> adelay
  dynaudnorm -> Stream #0:0 (pcm_s16le)
Decoder (codec none) not found for input stream #6:0

    at ChildProcess.exithandler (node:child_process:326:12)
    at ChildProcess.emit (node:events:365:28)
    at maybeClose (node:internal/child_process:1067:16)
    at Socket.<anonymous> (node:internal/child_process:453:11)
    at Socket.emit (node:events:365:28)
    at Pipe.<anonymous> (node:net:661:12) {
  killed: false,
  code: 1,
  signal: null,
  cmd: '<..truncated..>',
  stdout: '',
  stderr: '<..truncated..>'
}
```