### PR TITLE
Update WitherScore calculation to use new maximum score formula

### DIFF
--- a/osu.js
+++ b/osu.js
@@ -535,7 +535,7 @@ function convertStandardisedToClassic(score, object_count) {
 }
 
 function convertStandardisedToWither(score, object_count) {
-    return Math.round((Math.pow(object_count, 2) * 32.57) * Math.min(Math.pow(score / 1000000, 1.62), score / 1000000) + score * 0.1);
+    return Math.round(((Math.pow(object_count, 2) * 36.49) + object_count * 2096) * Math.min(Math.pow(score / 1000000, 1.62), score / 1000000) + score * 0.1);
 }
 
 function getModSettingsString(mods) {


### PR DESCRIPTION
Go from `objects^2 * 32.57 + 100_000` to `objects^2 * 36.49 + objects * 2_096 + 100_000` for maximum nomod classic score