### PR TITLE
fix: correct 'occured' to 'occurred' typo in 3 user-facing error messages

### DIFF
--- a/commands/time.js
+++ b/commands/time.js
@@ -49,7 +49,7 @@ module.exports = {
                     reject("Couldn't find this place");
                 }
             }).catch(err => {
-                reject("An error occured fetching the place");
+                reject("An error occurred fetching the place");
             });
         });
     }

--- a/osu.js
+++ b/osu.js
@@ -2268,7 +2268,7 @@ module.exports = {
             }
 
             if(bpms.length == 0)
-                throw 'An error occured getting the Beatmap BPM values';
+                throw 'An error occurred getting the Beatmap BPM values';
 
             bpms.push({ x: map.objects[map.objects.length - 1].time, y: bpms[bpms.length - 1]['y'] });
 
@@ -2305,7 +2305,7 @@ module.exports = {
             return buffer;
         }catch(e){
             helper.error(e);
-            throw 'An error occured creating the graph';
+            throw 'An error occurred creating the graph';
         }
     },
 


### PR DESCRIPTION
## Summary
Fixes 3 instances of the misspelled word 'occured' → 'occurred' in user-facing error messages.

## Changes
- `commands/time.js:52`: An error `occured` → `occurred` in Promise rejection message
- `osu.js:2271`: An error `occured` → `occurred` in Beatmap BPM error
- `osu.js:2308`: An error `occured` → `occurred` in graph creation error

All three are user-facing error messages shown to users when operations fail.

## Testing
Verified no other instances of 'occured' remain in the codebase.